### PR TITLE
Consolidate server URL into shared helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,19 +51,8 @@ the notebook on every save) — don't conflate the two if either gets fixed.
 
 ## Remote mode and server base_url
 
-`nb connect` stores the server URL exactly as given, including any base_url
-path prefix (e.g. `https://host/jupyter`), and every endpoint — REST API,
-Contents API, kernel WS, Y.js room WS, FileID index — lives under that prefix.
-Two URL-building pitfalls in `src/execution/server/ydoc.rs` were fixed for
-this (2026-08):
-
-- Never rebuild a URL from `scheme://host:port`, and never replace the path
-  with `Url::set_path()`: both silently drop the base_url prefix. Append route
-  segments onto the existing path with `path_segments_mut()` instead (same
-  pattern as `contents_url` in `client.rs`).
-- jupyter-collaboration registers its routes as Tornado regexes
-  `/api/collaboration/session/(.*)` and `/api/collaboration/room/(.*)`, so the
-  trailing slash after `session`/`room` is part of the match. The connect-time
-  probe calls `get_file_id` with an empty path; dropping the slash makes it
-  404 and the backend is silently misdetected as absent ("Mode: direct").
-  Verify route changes against the regexes in `jupyter_server_ydoc/app.py`.
+The server URL keeps any `base_url` path prefix (e.g. `https://host/jupyter`),
+and every endpoint lives under it. **Build all URLs through
+`crate::execution::server_url`** (`src/execution/server_url.rs`), never by
+hand: rebuilding from `scheme://host:port` or replacing the path silently
+drops the prefix.

--- a/src/execution/gateway/executor.rs
+++ b/src/execution/gateway/executor.rs
@@ -2,6 +2,7 @@
 
 use crate::execution::output_collector::KernelOutputCollector;
 use crate::execution::server::websocket::KernelWebSocket;
+use crate::execution::server_url;
 use crate::execution::types::{ExecutionConfig, ExecutionResult};
 use crate::execution::{ExecutionBackend, OutputCallback};
 use anyhow::{Context, Result};
@@ -48,10 +49,10 @@ impl RemoteKernelExecutor {
     }
 
     async fn discover_kernel_id(&self) -> Result<String> {
-        let url = format!("{}/api/kernels", self.gateway_url.trim_end_matches('/'));
+        let url = server_url::endpoint(&self.gateway_url, &["api", "kernels"])?;
         let response = self
             .http_client
-            .get(&url)
+            .get(url)
             .header("Authorization", self.auth_header())
             .send()
             .await
@@ -91,7 +92,7 @@ impl RemoteKernelExecutor {
     }
 
     async fn start_kernel(&self) -> Result<String> {
-        let url = format!("{}/api/kernels", self.gateway_url.trim_end_matches('/'));
+        let url = server_url::endpoint(&self.gateway_url, &["api", "kernels"])?;
         let mut body = serde_json::Map::new();
         if let Some(name) = self.config.kernel_name.as_ref() {
             body.insert("name".to_string(), serde_json::Value::String(name.clone()));
@@ -99,7 +100,7 @@ impl RemoteKernelExecutor {
 
         let response = self
             .http_client
-            .post(&url)
+            .post(url)
             .header("Authorization", self.auth_header())
             .json(&serde_json::Value::Object(body))
             .send()
@@ -134,16 +135,12 @@ impl RemoteKernelExecutor {
         Ok(kernel.id)
     }
 
-    fn ws_url_for_kernel(&self, kernel_id: &str) -> String {
-        let trimmed = self.gateway_url.trim_end_matches('/');
-        let base = if let Some(rest) = trimmed.strip_prefix("https://") {
-            format!("wss://{}", rest)
-        } else if let Some(rest) = trimmed.strip_prefix("http://") {
-            format!("ws://{}", rest)
-        } else {
-            trimmed.to_string()
-        };
-        format!("{}/api/kernels/{}/channels", base, kernel_id)
+    fn ws_url_for_kernel(&self, kernel_id: &str) -> Result<String> {
+        Ok(server_url::ws_endpoint(
+            &self.gateway_url,
+            &["api", "kernels", kernel_id, "channels"],
+        )?
+        .to_string())
     }
 
     async fn execute_cell(
@@ -206,7 +203,7 @@ impl ExecutionBackend for RemoteKernelExecutor {
                 .context("Failed to discover kernel from gateway")?,
         };
 
-        let ws_url = self.ws_url_for_kernel(&kernel_id);
+        let ws_url = self.ws_url_for_kernel(&kernel_id)?;
         let auth_value = self.auth_header();
         let ws = KernelWebSocket::connect_with_auth(&ws_url, &auth_value)
             .await
@@ -264,28 +261,38 @@ mod tests {
     fn ws_url_swaps_scheme_and_appends_channels_path() {
         let exec = executor("http://host:8888", "t", "token");
         assert_eq!(
-            exec.ws_url_for_kernel("abc"),
+            exec.ws_url_for_kernel("abc").unwrap(),
             "ws://host:8888/api/kernels/abc/channels"
         );
 
         let exec = executor("https://gw.example.com", "t", "token");
         assert_eq!(
-            exec.ws_url_for_kernel("abc"),
+            exec.ws_url_for_kernel("abc").unwrap(),
             "wss://gw.example.com/api/kernels/abc/channels"
         );
 
         // Trailing slash on the gateway URL must not produce a double slash.
         let exec = executor("https://gw.example.com/", "t", "token");
         assert_eq!(
-            exec.ws_url_for_kernel("abc"),
+            exec.ws_url_for_kernel("abc").unwrap(),
             "wss://gw.example.com/api/kernels/abc/channels"
         );
 
         // "http" inside a path segment must not be rewritten — only the scheme is.
         let exec = executor("https://gw.example.com/httpapi", "t", "token");
         assert_eq!(
-            exec.ws_url_for_kernel("abc"),
+            exec.ws_url_for_kernel("abc").unwrap(),
             "wss://gw.example.com/httpapi/api/kernels/abc/channels"
+        );
+    }
+
+    #[test]
+    fn ws_url_preserves_base_url_prefix() {
+        // A gateway mounted under a base_url prefix must keep it.
+        let exec = executor("https://gw.example.com/gateway", "t", "token");
+        assert_eq!(
+            exec.ws_url_for_kernel("abc").unwrap(),
+            "wss://gw.example.com/gateway/api/kernels/abc/channels"
         );
     }
 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -9,6 +9,7 @@ pub mod gateway;
 pub mod local;
 pub mod output_collector;
 pub mod server;
+pub mod server_url;
 pub mod types;
 
 use anyhow::Result;

--- a/src/execution/server/client.rs
+++ b/src/execution/server/client.rs
@@ -1,5 +1,6 @@
 //! HTTP client for Jupyter Server REST API
 
+use crate::execution::server_url;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -45,14 +46,15 @@ struct KernelSpec {
 }
 
 impl JupyterClient {
-    /// Create a new Jupyter Server client
+    /// Create a new Jupyter Server client. The URL is validated and
+    /// normalized eagerly so a bad URL fails here, not at first use.
     pub fn new(server_url: String, token: String) -> Result<Self> {
         let client = reqwest::Client::builder()
             .build()
             .context("Failed to create HTTP client")?;
 
         Ok(Self {
-            base_url: server_url.trim_end_matches('/').to_string(),
+            base_url: server_url::normalize(&server_url)?,
             token,
             client,
         })
@@ -60,10 +62,10 @@ impl JupyterClient {
 
     /// Test connection to the server
     pub async fn test_connection(&self) -> Result<()> {
-        let url = format!("{}/api", self.base_url);
+        let url = server_url::endpoint(&self.base_url, &["api"])?;
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .query(&[("token", &self.token)])
             .send()
             .await
@@ -81,10 +83,10 @@ impl JupyterClient {
 
     /// Get kernel info by ID
     pub async fn get_kernel(&self, kernel_id: &str) -> Result<KernelInfo> {
-        let url = format!("{}/api/kernels/{}", self.base_url, kernel_id);
+        let url = server_url::endpoint(&self.base_url, &["api", "kernels", kernel_id])?;
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .query(&[("token", &self.token)])
             .send()
             .await
@@ -103,10 +105,10 @@ impl JupyterClient {
     /// List all running kernels
     #[allow(dead_code)]
     pub async fn list_kernels(&self) -> Result<Vec<KernelInfo>> {
-        let url = format!("{}/api/kernels", self.base_url);
+        let url = server_url::endpoint(&self.base_url, &["api", "kernels"])?;
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .query(&[("token", &self.token)])
             .send()
             .await
@@ -127,14 +129,14 @@ impl JupyterClient {
     /// Start a new kernel
     #[allow(dead_code)]
     pub async fn start_kernel(&self, kernel_name: &str) -> Result<KernelInfo> {
-        let url = format!("{}/api/kernels", self.base_url);
+        let url = server_url::endpoint(&self.base_url, &["api", "kernels"])?;
         let payload = serde_json::json!({
             "name": kernel_name
         });
 
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .query(&[("token", &self.token)])
             .json(&payload)
             .send()
@@ -155,10 +157,10 @@ impl JupyterClient {
 
     /// List all sessions
     pub async fn list_sessions(&self) -> Result<Vec<SessionInfo>> {
-        let url = format!("{}/api/sessions", self.base_url);
+        let url = server_url::endpoint(&self.base_url, &["api", "sessions"])?;
         let response = self
             .client
-            .get(&url)
+            .get(url)
             .query(&[("token", &self.token)])
             .send()
             .await
@@ -184,7 +186,7 @@ impl JupyterClient {
         kernel_id: &str,
         kernel_name: &str,
     ) -> Result<SessionInfo> {
-        let url = format!("{}/api/sessions", self.base_url);
+        let url = server_url::endpoint(&self.base_url, &["api", "sessions"])?;
         let payload = CreateSessionRequest {
             path: notebook_path.to_string(),
             name: filename_from_path(notebook_path),
@@ -197,7 +199,7 @@ impl JupyterClient {
 
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .query(&[("token", &self.token)])
             .json(&payload)
             .send()
@@ -228,7 +230,7 @@ impl JupyterClient {
         notebook_path: &str,
         kernel_name: &str,
     ) -> Result<SessionInfo> {
-        let url = format!("{}/api/sessions", self.base_url);
+        let url = server_url::endpoint(&self.base_url, &["api", "sessions"])?;
         let payload = CreateSessionRequest {
             path: notebook_path.to_string(),
             name: filename_from_path(notebook_path),
@@ -241,7 +243,7 @@ impl JupyterClient {
 
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .query(&[("token", &self.token)])
             .json(&payload)
             .send()
@@ -264,10 +266,10 @@ impl JupyterClient {
 
     /// Restart a kernel
     pub async fn restart_kernel(&self, kernel_id: &str) -> Result<KernelInfo> {
-        let url = format!("{}/api/kernels/{}/restart", self.base_url, kernel_id);
+        let url = server_url::endpoint(&self.base_url, &["api", "kernels", kernel_id, "restart"])?;
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .query(&[("token", &self.token)])
             .send()
             .await
@@ -286,10 +288,10 @@ impl JupyterClient {
     /// Delete a session
     #[allow(dead_code)]
     pub async fn delete_session(&self, session_id: &str) -> Result<()> {
-        let url = format!("{}/api/sessions/{}", self.base_url, session_id);
+        let url = server_url::endpoint(&self.base_url, &["api", "sessions", session_id])?;
         let response = self
             .client
-            .delete(&url)
+            .delete(url)
             .query(&[("token", &self.token)])
             .send()
             .await
@@ -303,19 +305,7 @@ impl JupyterClient {
     }
 
     fn contents_url(&self, path: &str) -> Result<String> {
-        let mut url = url::Url::parse(&self.base_url).context("Invalid server URL")?;
-        {
-            let mut segments = url
-                .path_segments_mut()
-                .map_err(|_| anyhow::anyhow!("Server URL cannot be a base"))?;
-            segments.push("api").push("contents");
-            for part in path.split('/') {
-                if !part.is_empty() {
-                    segments.push(part);
-                }
-            }
-        }
-        Ok(url.to_string())
+        Ok(server_url::endpoint_with_path(&self.base_url, &["api", "contents"], path)?.to_string())
     }
 
     /// Read a notebook from the server via the Contents API.
@@ -384,21 +374,14 @@ impl JupyterClient {
 
     /// Get the WebSocket URL for a kernel
     pub fn get_ws_url(&self, kernel_id: &str, session_id: Option<&str>) -> String {
-        let ws_base = self
-            .base_url
-            .replace("http://", "ws://")
-            .replace("https://", "wss://");
+        let mut url =
+            server_url::ws_endpoint(&self.base_url, &["api", "kernels", kernel_id, "channels"])
+                .expect("server URL was validated at construction");
         if let Some(sid) = session_id {
-            format!(
-                "{}/api/kernels/{}/channels?session_id={}&token={}",
-                ws_base, kernel_id, sid, self.token
-            )
-        } else {
-            format!(
-                "{}/api/kernels/{}/channels?token={}",
-                ws_base, kernel_id, self.token
-            )
+            url.query_pairs_mut().append_pair("session_id", sid);
         }
+        url.query_pairs_mut().append_pair("token", &self.token);
+        url.to_string()
     }
 
     /// Probe whether the server supports `POST /api/kernels/{id}/execute`.
@@ -406,7 +389,7 @@ impl JupyterClient {
     /// - 400 or 200 means the endpoint exists (server understands the route)
     /// - 404 or 405 means the endpoint is absent (fall back to kernel WS)
     pub async fn probe_execute_api(&self, kernel_id: &str) -> Result<bool> {
-        let url = format!("{}/api/kernels/{}/execute", self.base_url, kernel_id);
+        let url = server_url::endpoint(&self.base_url, &["api", "kernels", kernel_id, "execute"])?;
         let payload = serde_json::json!({
             "document_id": "",
             "cells": []
@@ -414,7 +397,7 @@ impl JupyterClient {
 
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .query(&[("token", &self.token)])
             .json(&payload)
             .send()
@@ -438,11 +421,11 @@ impl JupyterClient {
         kernel_id: &str,
         request: &ExecuteCellsRequest,
     ) -> Result<ExecuteCellsResponse> {
-        let url = format!("{}/api/kernels/{}/execute", self.base_url, kernel_id);
+        let url = server_url::endpoint(&self.base_url, &["api", "kernels", kernel_id, "execute"])?;
 
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .query(&[("token", &self.token)])
             .json(request)
             .send()
@@ -598,6 +581,32 @@ mod tests {
             "trailing slash must not produce double-slash in URL: {url}"
         );
         assert!(url.contains("/api/kernels/k/channels"));
+    }
+
+    #[test]
+    fn test_get_ws_url_preserves_base_url_prefix() {
+        // Server mounted under a base_url (e.g. /jupyter) — the ws URL must
+        // keep the prefix, not rebuild from host/port.
+        let c = client("https://host/jupyter");
+        let url = c.get_ws_url("kid1", None);
+        assert_eq!(
+            url,
+            "wss://host/jupyter/api/kernels/kid1/channels?token=tok"
+        );
+
+        let c = client("http://host:8888/foo/bar/");
+        let url = c.get_ws_url("kid2", Some("sid"));
+        assert_eq!(
+            url,
+            "ws://host:8888/foo/bar/api/kernels/kid2/channels?session_id=sid&token=tok"
+        );
+    }
+
+    #[test]
+    fn test_new_rejects_invalid_server_url() {
+        assert!(JupyterClient::new("not a url".to_string(), "t".to_string()).is_err());
+        assert!(JupyterClient::new("host:8888".to_string(), "t".to_string()).is_err());
+        assert!(JupyterClient::new("ftp://host".to_string(), "t".to_string()).is_err());
     }
 
     #[test]

--- a/src/execution/server/ydoc.rs
+++ b/src/execution/server/ydoc.rs
@@ -6,7 +6,6 @@ use nbformat::v4::Output;
 use reqwest::Client as HttpClient;
 use serde::Deserialize;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
-use url::Url;
 use yrs::encoding::varint::VarInt;
 use yrs::encoding::write::Write;
 use yrs::types::ToJson;
@@ -15,6 +14,7 @@ use yrs::updates::encoder::Encode;
 use yrs::{Array, ArrayRef, Doc, GetString, Map, ReadTxn, StateVector, Transact, Update};
 
 use super::output_conversion::{update_cell_execution_count, update_cell_outputs};
+use crate::execution::server_url;
 
 /// Outputs and execution_count read from a Y.js cell
 pub struct YDocCellOutputs {
@@ -168,9 +168,9 @@ impl YDocClient {
     ) -> Result<(String, Option<String>)> {
         let http_client = HttpClient::new();
 
-        let index_url = format!("{}/api/fileid/index", server_url);
+        let index_url = server_url::endpoint(server_url, &["api", "fileid", "index"])?;
         let response = http_client
-            .post(&index_url)
+            .post(index_url)
             .query(&[("path", notebook_path)])
             .header("Authorization", format!("token {}", token))
             .send()
@@ -208,29 +208,17 @@ impl YDocClient {
         // jupyter-server-documents is absent. Fall back to the
         // jupyter-collaboration session endpoint, which indexes the file if
         // needed and returns its fileId.
-        //
-        // Append the route onto the existing path rather than set_path():
-        // a server mounted under a base_url (e.g. /jupyter) must keep that
-        // prefix, and set_path() replaces the whole path.
-        let mut session_url = Url::parse(server_url).context("Invalid server URL")?;
-        {
-            let mut segments = session_url
-                .path_segments_mut()
-                .map_err(|_| anyhow::anyhow!("Server URL cannot be a base"))?;
-            segments.push("api").push("collaboration").push("session");
-            let parts: Vec<&str> = notebook_path.split('/').filter(|p| !p.is_empty()).collect();
-            for part in &parts {
-                segments.push(part);
-            }
-            // jupyter-collaboration registers this route as
-            // /api/collaboration/session/(.*) (Tornado regex): the trailing
-            // slash after "session" is part of the match. The connect-time
-            // probe uses an empty path; without the slash it 404s and the
-            // backend is misdetected as absent.
-            if parts.is_empty() {
-                segments.push("");
-            }
-        }
+        // jupyter-collaboration registers this route as
+        // /api/collaboration/session/(.*) (Tornado regex): the trailing
+        // slash after "session" is part of the match. `endpoint_with_path`
+        // appends the notebook path and yields the trailing slash for the
+        // empty-path connect probe; without it the probe 404s and the
+        // backend is misdetected as absent.
+        let session_url = server_url::endpoint_with_path(
+            server_url,
+            &["api", "collaboration", "session"],
+            notebook_path,
+        )?;
         let response = http_client
             .put(session_url)
             .header("Authorization", format!("token {}", token))
@@ -273,20 +261,18 @@ impl YDocClient {
         token: &str,
         session_id: Option<&str>,
     ) -> Result<String> {
-        // Keep any base_url path prefix (e.g. /jupyter) by swapping the
-        // scheme in place and appending the room route to the existing path,
+        // ws_endpoint swaps the scheme in place and appends the room route
+        // onto the existing path, keeping any base_url prefix (e.g. /jupyter)
         // rather than rebuilding the URL from host/port (which drops it).
-        let ws_url_str = server_url
-            .replace("https://", "wss://")
-            .replace("http://", "ws://");
-        let mut ws_url = Url::parse(&ws_url_str).context("Invalid server URL")?;
-        {
-            let mut segments = ws_url
-                .path_segments_mut()
-                .map_err(|_| anyhow::anyhow!("Server URL cannot be a base"))?;
-            segments.push("api").push("collaboration").push("room");
-            segments.push(&format!("json:notebook:{}", file_id));
-        }
+        let mut ws_url = server_url::ws_endpoint(
+            server_url,
+            &[
+                "api",
+                "collaboration",
+                "room",
+                &format!("json:notebook:{}", file_id),
+            ],
+        )?;
 
         ws_url.query_pairs_mut().append_pair("token", token);
         if let Some(sid) = session_id {

--- a/src/execution/server/ydoc_execution.rs
+++ b/src/execution/server/ydoc_execution.rs
@@ -7,6 +7,7 @@ use super::RemoteExecutor;
 use crate::execution::server::client::{
     compute_source_hash, ExecuteCellSpec, ExecuteCellsRequest, ExecuteCellsResponse,
 };
+use crate::execution::server_url;
 use crate::execution::types::{ExecutionError, ExecutionResult};
 use anyhow::{Context, Result};
 use jupyter_protocol::messaging::JupyterMessageContent;
@@ -20,7 +21,9 @@ async fn fetch_output(
     token: &str,
     url_path: &str,
 ) -> Option<nbformat::v4::Output> {
-    let url = format!("{}{}", server_url, url_path);
+    // Resolve the server-relative output URL (e.g. /api/contents/...) against
+    // the server base, keeping any base_url prefix.
+    let url = server_url::endpoint_with_path(server_url, &[], url_path).ok()?;
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
     let mut backoff_ms = 100u64; // initial delay before first fetch
 
@@ -28,7 +31,12 @@ async fn fetch_output(
     tokio::time::sleep(std::time::Duration::from_millis(backoff_ms)).await;
 
     loop {
-        if let Ok(resp) = http.get(&url).query(&[("token", token)]).send().await {
+        if let Ok(resp) = http
+            .get(url.clone())
+            .query(&[("token", token)])
+            .send()
+            .await
+        {
             if resp.status().is_success() {
                 if let Ok(text) = resp.text().await {
                     if let Ok(output) = serde_json::from_str::<nbformat::v4::Output>(&text) {

--- a/src/execution/server/ydoc_execution.rs
+++ b/src/execution/server/ydoc_execution.rs
@@ -22,7 +22,9 @@ async fn fetch_output(
     url_path: &str,
 ) -> Option<nbformat::v4::Output> {
     // Resolve the server-relative output URL (e.g. /api/contents/...) against
-    // the server base, keeping any base_url prefix.
+    // the server base, keeping any base_url prefix. Assumes url_path
+    // components are URL-safe; endpoint_with_path re-encodes them.
+    // jsd's file_id/cell_id/index are URL-safe, so no double-encoding happens today.
     let url = server_url::endpoint_with_path(server_url, &[], url_path).ok()?;
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
     let mut backoff_ms = 100u64; // initial delay before first fetch

--- a/src/execution/server_url.rs
+++ b/src/execution/server_url.rs
@@ -1,0 +1,295 @@
+//! Shared Jupyter server URL helpers.
+//!
+//! Every component that talks to a Jupyter server or kernel gateway
+//! (`JupyterClient`, `YDocClient`, `RemoteExecutor`, `RemoteKernelExecutor`,
+//! externalized-output fetches) builds its endpoint URLs here so the server's
+//! `base_url` path prefix (e.g. `/jupyter`) is always preserved — rebuilding
+//! from host/port or replacing the path drops it (commit afd0a47).
+//!
+//! Callers keep the server URL as a plain `String` (as it appears in
+//! `ExecutionMode`, config and commands) and pass it to the builders at each
+//! use; all builders share a single core ([`append_parts`]).
+
+use anyhow::{bail, Context, Result};
+use url::Url;
+
+/// Validate a Jupyter server URL and return its canonical form with any
+/// trailing slash stripped.
+///
+/// Only `http`/`https` are accepted — WebSocket URLs are derived by swapping
+/// the scheme, so the server URL must have an HTTP scheme, and a URL without
+/// any scheme (e.g. `host:8888`) is a hard error instead of being silently
+/// passed through. Call this at construction boundaries (client/executor
+/// constructors) to fail fast on invalid URLs; the endpoint builders below
+/// validate again on first use.
+pub fn normalize(server_url: &str) -> Result<String> {
+    let url = Url::parse(server_url.trim_end_matches('/')).context("Invalid server URL")?;
+    match url.scheme() {
+        "http" | "https" => {}
+        s => bail!(
+            "Invalid server URL '{}': scheme must be http or https, got '{}'",
+            server_url,
+            s
+        ),
+    }
+    if url.host_str().is_none() {
+        bail!("Invalid server URL '{}': missing host", server_url);
+    }
+    Ok(url.to_string())
+}
+
+/// Core builder shared by all endpoint helpers: parse `server_url`, then
+/// append `parts` as path segments, preserving any `base_url` prefix.
+fn append_parts<'a>(server_url: &str, parts: impl Iterator<Item = &'a str>) -> Result<Url> {
+    let mut url = Url::parse(server_url).context("Invalid server URL")?;
+    {
+        let mut segments = url
+            .path_segments_mut()
+            .map_err(|_| anyhow::anyhow!("Server URL cannot be a base"))?;
+        for part in parts {
+            segments.push(part);
+        }
+    }
+    Ok(url)
+}
+
+/// Build an endpoint URL by appending route `segments` to the server URL's
+/// existing path, keeping any `base_url` prefix. Returns a `Url` ready to
+/// pass to reqwest or to append query parameters to.
+pub fn endpoint(server_url: &str, segments: &[&str]) -> Result<Url> {
+    append_parts(server_url, segments.iter().copied())
+}
+
+/// Build an endpoint URL for a resource addressed by a server path: append
+/// the `api` route segments, then append `path`'s components. A leading `/`
+/// on `path` is trimmed; a `?query` suffix is preserved as a query string.
+///
+/// `path` is a path-like string of raw, unescaped components (a notebook
+/// path, a server-relative URL) — each is percent-encoded as one segment, so
+/// a filename with spaces or `#` stays valid. Pass raw names, not
+/// already-escaped ones (those would be double-escaped).
+///
+/// A trailing `/` is preserved: an empty `path` yields a trailing slash,
+/// which the collaboration-session route needs for its Tornado regex
+/// `session/(.*)`.
+///
+/// With `api = &[]` this also resolves server-relative URLs (externalized
+/// output URLs read from Y.js `metadata.url`).
+pub fn endpoint_with_path(server_url: &str, api: &[&str], path: &str) -> Result<Url> {
+    let (path_part, query_part) = match path.split_once('?') {
+        Some((p, q)) => (p, Some(q)),
+        None => (path, None),
+    };
+    // Split into raw components so `path_segments_mut` percent-encodes each
+    // one; trim the leading `/` so it doesn't become an empty first segment
+    // (which would serialize as `//`).
+    let mut url = append_parts(
+        server_url,
+        api.iter()
+            .copied()
+            .chain(path_part.trim_start_matches('/').split('/')),
+    )?;
+    url.set_query(query_part);
+    Ok(url)
+}
+
+/// Build a WebSocket endpoint URL: like [`endpoint`], but with
+/// `http`→`ws` / `https`→`wss` swapped in place. Path, port and `base_url`
+/// prefix are preserved; an `http` substring inside a path segment is never
+/// rewritten.
+pub fn ws_endpoint(server_url: &str, segments: &[&str]) -> Result<Url> {
+    let mut url = endpoint(server_url, segments)?;
+    let scheme = match url.scheme() {
+        "http" => "ws",
+        "https" => "wss",
+        s => bail!("Cannot build WebSocket URL from scheme '{}'", s),
+    };
+    url.set_scheme(scheme)
+        .map_err(|_| anyhow::anyhow!("Failed to set WebSocket scheme"))?;
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_accepts_plain_root_url() {
+        assert_eq!(
+            normalize("http://127.0.0.1:8888").unwrap(),
+            "http://127.0.0.1:8888/"
+        );
+    }
+
+    #[test]
+    fn normalize_keeps_base_url_path_prefix() {
+        assert_eq!(
+            normalize("https://host/jupyter").unwrap(),
+            "https://host/jupyter"
+        );
+    }
+
+    #[test]
+    fn normalize_strips_trailing_slash_from_path() {
+        assert_eq!(
+            normalize("http://host:8888/foo/bar/").unwrap(),
+            "http://host:8888/foo/bar"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_non_http_scheme() {
+        let err = normalize("ftp://host").unwrap_err();
+        assert!(err.to_string().contains("http or https"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_rejects_scheme_less_url() {
+        // "host:8888" parses as scheme "host" + opaque "8888"; the old
+        // gateway code silently passed it through, reqwest then rejected it
+        // later with a worse error.
+        let err = normalize("host:8888").unwrap_err();
+        assert!(err.to_string().contains("http or https"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_rejects_garbage() {
+        assert!(normalize("not a url").is_err());
+        assert!(normalize("http://").is_err());
+    }
+
+    #[test]
+    fn endpoint_appends_segments_onto_base_url_prefix() {
+        let url = endpoint(
+            "https://my-jupyter.example.com/jupyter",
+            &["api", "kernels", "kid1"],
+        )
+        .unwrap();
+        assert_eq!(
+            url.to_string(),
+            "https://my-jupyter.example.com/jupyter/api/kernels/kid1"
+        );
+    }
+
+    #[test]
+    fn endpoint_on_root_url() {
+        let url = endpoint("http://host:8888", &["api", "sessions"]).unwrap();
+        assert_eq!(url.to_string(), "http://host:8888/api/sessions");
+    }
+
+    #[test]
+    fn endpoint_with_path_appends_path_components() {
+        let url = endpoint_with_path(
+            "http://host:8888/jupyter",
+            &["api", "contents"],
+            "dir/nb.ipynb",
+        )
+        .unwrap();
+        assert_eq!(
+            url.to_string(),
+            "http://host:8888/jupyter/api/contents/dir/nb.ipynb"
+        );
+    }
+
+    #[test]
+    fn endpoint_with_path_escapes_components_as_raw_path_parts() {
+        // `path` is a path-like string, not a URL: a filename with spaces or
+        // `#` must be escaped as a single valid segment.
+        let url = endpoint_with_path(
+            "http://host:8888",
+            &["api", "contents"],
+            "/my dir/nb#1.ipynb",
+        )
+        .unwrap();
+        assert_eq!(
+            url.to_string(),
+            "http://host:8888/api/contents/my%20dir/nb%231.ipynb"
+        );
+    }
+
+    #[test]
+    fn endpoint_with_path_empty_path_yields_trailing_slash() {
+        // The collaboration-session route is matched by the Tornado regex
+        // `session/(.*)`; the connect-time probe uses an empty path, so the
+        // empty path must produce the trailing slash itself.
+        let url = endpoint_with_path(
+            "http://host:8888/jupyter",
+            &["api", "collaboration", "session"],
+            "",
+        )
+        .unwrap();
+        assert_eq!(
+            url.to_string(),
+            "http://host:8888/jupyter/api/collaboration/session/"
+        );
+    }
+
+    #[test]
+    fn endpoint_with_path_resolves_relative_url() {
+        // server-relative URLs (externalized outputs) with no api prefix
+        let url = endpoint_with_path(
+            "http://host:8888/jupyter",
+            &[],
+            "/api/contents/file-1/outputs/0",
+        )
+        .unwrap();
+        assert_eq!(
+            url.to_string(),
+            "http://host:8888/jupyter/api/contents/file-1/outputs/0"
+        );
+    }
+
+    #[test]
+    fn endpoint_with_path_keeps_query_string() {
+        let url = endpoint_with_path(
+            "http://host:8888/jupyter",
+            &[],
+            "/api/contents/file-1?format=json",
+        )
+        .unwrap();
+        assert_eq!(
+            url.to_string(),
+            "http://host:8888/jupyter/api/contents/file-1?format=json"
+        );
+    }
+
+    #[test]
+    fn ws_endpoint_swaps_scheme_keeping_port_and_prefix() {
+        let ws = ws_endpoint(
+            "http://host:8888/foo/bar",
+            &["api", "kernels", "kid1", "channels"],
+        )
+        .unwrap();
+        assert_eq!(
+            ws.to_string(),
+            "ws://host:8888/foo/bar/api/kernels/kid1/channels"
+        );
+    }
+
+    #[test]
+    fn ws_endpoint_swaps_https_to_wss() {
+        let ws = ws_endpoint(
+            "https://my-jupyter.example.com/jupyter",
+            &["api", "collaboration", "room", "json:notebook:file-1"],
+        )
+        .unwrap();
+        assert_eq!(
+            ws.to_string(),
+            "wss://my-jupyter.example.com/jupyter/api/collaboration/room/json:notebook:file-1"
+        );
+    }
+
+    #[test]
+    fn ws_endpoint_does_not_rewrite_http_inside_path() {
+        // Only the scheme is swapped; "http" inside a path segment must stay.
+        let ws = ws_endpoint(
+            "https://gw.example.com/httpapi",
+            &["api", "kernels", "abc", "channels"],
+        )
+        .unwrap();
+        assert_eq!(
+            ws.to_string(),
+            "wss://gw.example.com/httpapi/api/kernels/abc/channels"
+        );
+    }
+}


### PR DESCRIPTION
URL building was scattered across four subtly different styles: string concat on a trimmed base (`JupyterClient` REST calls), string concat on the raw untrimmed URL (the FileID index probe), `Url::parse` + `path_segments_mut` (the collaboration URLs fixed in afd0a47), and `strip_prefix` scheme swaps (gateway).

Introduce `src/execution/server_url.rs` as the single place that parses and builds server URLs, and route every consumer through it:

- `normalize`: validate `http(s)`, strip trailing slash
- `endpoint` / `endpoint_with_path`: append route segments / a split path to the existing path, keeping the `base_url` prefix
- `ws_endpoint`: endpoint + in-place `http`->`ws` / `https`->`wss` scheme swap

All builders share one `append_parts` core. Callers keep plain `String`s end to end (deliberately no parsed URL type, after weighing one) and parse per use; builders return `Url` so query params can be appended without re-parsing.

Closes #118 